### PR TITLE
Fix some broken and duplicated installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A Chassis extension to install and configure [XHGui](https://github.com/perftool
 1. Add this extension to your extensions directory `git clone --recursive git@github.com:Chassis/Chassis-XHGui.git extensions/chassis-xhgui`
 2. Note: **The folder that you clone into must be called** `chassis-xhgui`.
 3. Run `vagrant provision`.
-4. Browse to [http://vagrant.local/xhgui](http://vagrant.local/xhgui) in a browser or if you have a custom host hame it will be [http://<yourhost>.local/xghui](http://<yourhost>.local/xghui)
-
 
 ## Alternative Installation
 1. Add `- chassis/chassis-xhgui` to your `extensions` in [yaml](http://docs.chassis.io/en/latest/config/) files. e.g.
@@ -15,9 +13,14 @@ A Chassis extension to install and configure [XHGui](https://github.com/perftool
 	- chassis/chassis-xhgui
 	```
 2. Run `vagrant provision`.
-3. Browse to [http://vagrant.local/xhgui](http://vagrant.local/xhgui) in a browser or if you have a custom host hame it will be [http://yourhostname.local/xghui](http://yourhostname.local/xghui). If you're using [custom paths](http://docs.chassis.io/en/latest/config/#paths) you'll need to change the URL to add your custom base. For example: If you've Chassis located in a `chassis` folder then the URL will be [http://vagrant.local/chassis/xhgui](http://vagrant.local/chassis/xhgui) or [http://yourhostname.local/chassis/xghui](http://yourhostname.local/chassis/xghui).
-4. **Please note:** `vagrant provision` can take quite a few minutes due to the amount of [Composer](https://getcomposer.org/) dependencies in Xhgui.  So when you see the provisioning process taking a long time on `Service[php7.0-fpm]` please be patient as this is the stage where Composer dependencies are being installed. 
-5. Browse to [http://vagrant.local/xhgui](http://vagrant.local/xhgui) in a browser or if you have a custom host hame it will be [http://<yourhost>.local/xghui](http://<yourhost>.local/xghui)
+
+> **Please note:** `vagrant provision` can take quite a few minutes due to the amount of [Composer](https://getcomposer.org/) dependencies in XHGui.  So when you see the provisioning process taking a long time on `Service[php7.0-fpm]` please be patient as this is the stage where Composer dependencies are being installed. 
+
+## Usage
+
+Browse to [http://vagrant.local/xhgui](http://vagrant.local/xhgui) in a browser. If you have a custom host hame it will be `http://<yourhostname>.local/xghui`.
+
+If you're using [custom paths](http://docs.chassis.io/en/latest/config/#paths) you'll need to change the URL to add your custom base. For example: If you've Chassis located in a `chassis` folder then the URL will be [http://vagrant.local/chassis/xhgui](http://vagrant.local/chassis/xhgui) or `http://<yourhostname>.local/chassis/xghui`.
 
 ## Uninstallation
 1. Add `- chassis/chassis-xhgui` to your `disabled_extensions` in [yaml](http://docs.chassis.io/en/latest/config/) files. e.g.
@@ -26,7 +29,6 @@ A Chassis extension to install and configure [XHGui](https://github.com/perftool
 	- chassis/chassis-xhgui
 	```
 2. Run `vagrant provision`.
-3. Browse to [http://vagrant.local/xhgui](http://vagrant.local/xhgui) in a browser or if you have a custom host hame it will be [http://yourhost.local/xghui](http://yourhost.local/xghui)
 
 ## Screenshots
 


### PR DESCRIPTION
The example links that contain angle brackets are broken because they're rendered as HTML elements. Removes some duplication too.